### PR TITLE
Add zombie transaction detection script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # zombie
+
+This repository contains a small Python utility for identifying recurring "zombie" credit card transactions. Forgotten cards often continue paying for services that are no longer used, wasting significant amounts of money.
+
+## Usage
+Prepare a CSV file with at least `Date`, `Description` and `Amount` columns. Run the script specifying the CSV file:
+
+```bash
+python zombie_transactions.py transactions.csv -n 3
+```
+
+The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
+

--- a/tests/test_zombie_transactions.py
+++ b/tests/test_zombie_transactions.py
@@ -1,0 +1,34 @@
+import io
+import unittest
+from zombie_transactions import find_recurring_transactions
+
+
+SAMPLE_CSV = """Date,Description,Amount
+2024-01-15,ServiceA,10.00
+2024-02-15,ServiceA,10.00
+2024-03-15,ServiceA,10.00
+2024-01-10,ServiceB,5.00
+2024-02-11,ServiceC,7.00
+2024-03-11,ServiceC,7.00
+"""
+
+
+class ZombieTest(unittest.TestCase):
+    def test_recurring_detection(self):
+        with io.StringIO(SAMPLE_CSV) as f:
+            # write to temp file because function expects a path
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tf:
+                tf.write(f.getvalue())
+                path = tf.name
+
+            results = find_recurring_transactions(path, months_threshold=2)
+            self.assertIn(("ServiceA", 10.0), results)
+            self.assertIn(("ServiceC", 7.0), results)
+            self.assertNotIn(("ServiceB", 5.0), results)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/zombie_transactions.py
+++ b/zombie_transactions.py
@@ -1,0 +1,53 @@
+import csv
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Tuple, Dict
+
+
+def _get_month(date_str: str) -> str:
+    """Return YYYY-MM for a date string."""
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y/%m/%d"):
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            return dt.strftime("%Y-%m")
+        except ValueError:
+            continue
+    raise ValueError(f"Unrecognized date format: {date_str}")
+
+
+def find_recurring_transactions(
+    file_path: str, months_threshold: int = 2
+) -> List[Tuple[str, float]]:
+    """Return a list of (description, amount) that appear in multiple months."""
+    seen: Dict[Tuple[str, float], set] = defaultdict(set)
+    with open(file_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            description = row.get("Description") or row.get("Payee") or ""
+            amount = float(row.get("Amount"))
+            date_str = row.get("Date") or row.get("Transaction Date") or ""
+            month = _get_month(date_str)
+            seen[(description.strip(), amount)].add(month)
+    return [
+        (desc, amt) for (desc, amt), months in seen.items() if len(months) >= months_threshold
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Find recurring transactions across multiple months"
+    )
+    parser.add_argument("csv_file", help="CSV file of credit card transactions")
+    parser.add_argument(
+        "-n",
+        "--months",
+        type=int,
+        default=2,
+        help="Minimum number of months for a transaction to be considered recurring",
+    )
+    args = parser.parse_args()
+    for desc, amt in find_recurring_transactions(args.csv_file, args.months):
+        print(f"{desc}: ${amt:.2f}")
+


### PR DESCRIPTION
## Summary
- add Python utility `zombie_transactions.py` to find recurring transactions
- add test coverage
- update README with usage instructions
- ignore `__pycache__`

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py' -v`


------
https://chatgpt.com/codex/tasks/task_e_685c42fa1158832aa60cc2871ec71353