### PR TITLE
Add GitHub Pages UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ python zombie_transactions.py transactions.csv -n 3
 
 The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
 
+## Web interface
+A basic web interface is available under `docs/`. GitHub Pages can serve this directory so the analysis can be run directly in the browser:
+
+1. Commit the contents of the `docs/` folder.
+2. In your repository settings on GitHub, enable **GitHub Pages** and choose the **docs/** folder as the source.
+3. Visit the provided URL to upload a CSV file and see recurring charges without installing anything locally.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Zombie Transactions Analyzer</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js" integrity="sha512-4VafBf+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHfoalGoVYLRNvKcJsteVEhDWUpAJZciV06P88GJEpXHIFaY5w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+label { display: block; margin-top: 1em; }
+pre { background: #f4f4f4; padding: 1em; }
+</style>
+</head>
+<body>
+<h1>Zombie Transactions Analyzer</h1>
+<label>
+CSV File:
+<input type="file" id="csvFile" accept=".csv">
+</label>
+<label>
+Months threshold:
+<input type="number" id="months" value="2" min="1">
+</label>
+<button id="analyzeBtn">Analyze</button>
+<pre id="output"></pre>
+<script>
+function getMonth(dateStr) {
+  const d = new Date(dateStr);
+  if (isNaN(d)) throw new Error('Unrecognized date format: ' + dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function findRecurringTransactions(rows, monthsThreshold) {
+  const seen = {};
+  rows.forEach(row => {
+    const desc = (row.Description || row.Payee || '').trim();
+    const amount = parseFloat(row.Amount);
+    const dateStr = row.Date || row['Transaction Date'] || '';
+    if (!desc || isNaN(amount) || !dateStr) return;
+    let month;
+    try { month = getMonth(dateStr); } catch (e) { return; }
+    const key = desc + '||' + amount;
+    if (!seen[key]) seen[key] = new Set();
+    seen[key].add(month);
+  });
+  const results = [];
+  Object.keys(seen).forEach(key => {
+    if (seen[key].size >= monthsThreshold) {
+      const [desc, amount] = key.split('||');
+      results.push({ description: desc, amount: parseFloat(amount) });
+    }
+  });
+  return results;
+}
+
+function analyze() {
+  const fileInput = document.getElementById('csvFile');
+  const months = parseInt(document.getElementById('months').value, 10) || 2;
+  const output = document.getElementById('output');
+  const file = fileInput.files[0];
+  if (!file) { output.textContent = 'Please select a CSV file.'; return; }
+  Papa.parse(file, {
+    header: true,
+    skipEmptyLines: true,
+    complete: function(results) {
+      const recurring = findRecurringTransactions(results.data, months);
+      if (recurring.length === 0) {
+        output.textContent = 'No recurring transactions found.';
+      } else {
+        output.textContent = recurring.map(r => `${r.description}: $${r.amount.toFixed(2)}`).join('\n');
+      }
+    }
+  });
+}
+
+document.getElementById('analyzeBtn').addEventListener('click', analyze);
+</script>
+</body>
+</html>

--- a/tests/test_zombie_transactions.py
+++ b/tests/test_zombie_transactions.py
@@ -1,5 +1,9 @@
 import io
 import unittest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from zombie_transactions import find_recurring_transactions
 
 


### PR DESCRIPTION
## Summary
- add a basic browser interface in `docs/` for analysing CSVs
- explain how to enable the web UI via GitHub Pages
- update tests to import the module correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c43f98d14832a8156824523b8618c