### PR TITLE
Improve zombie_transactions robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ python zombie_transactions.py transactions.csv -n 3
 
 The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
 
+Rows with missing or malformed data are ignored so you can analyze statements that contain occasional inconsistencies without errors.
+
 ## Web interface
 A basic web interface is available under `docs/`. GitHub Pages can serve this directory so the analysis can be run directly in the browser:
 

--- a/tests/test_zombie_transactions.py
+++ b/tests/test_zombie_transactions.py
@@ -32,6 +32,24 @@ class ZombieTest(unittest.TestCase):
             self.assertIn(("ServiceC", 7.0), results)
             self.assertNotIn(("ServiceB", 5.0), results)
 
+    def test_ignore_invalid_rows(self):
+        invalid_csv = """Date,Description,Amount
+2024-01-01,ServiceX,9.99
+bad-date,ServiceX,9.99
+2024-02-01,ServiceX,9.99
+2024-03-01,,10
+2024-03-05,ServiceX,notanumber
+"""
+        with io.StringIO(invalid_csv) as f:
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tf:
+                tf.write(f.getvalue())
+                path = tf.name
+
+            results = find_recurring_transactions(path, months_threshold=2)
+            self.assertIn(("ServiceX", 9.99), results)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- skip malformed CSV rows while analyzing transactions
- update README about ignoring bad data
- test invalid row handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4b8b1bf8832aad1349819d31fcc2