### PR TITLE
Add dark mode support and improved styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A basic web interface is available under `docs/`. GitHub Pages can serve this di
 2. In your repository settings on GitHub, enable **GitHub Pages** and choose the **docs/** folder as the source.
 3. Visit the provided URL to upload a CSV file and see recurring charges without installing anything locally.
 
+The page now supports dark mode automatically and features an improved layout for an epic experience.
+
 
 ## Local upload server
 If you prefer a minimal server-based approach, run `upload_server.py`:

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,9 +6,41 @@
 <title>Zombie Transactions Analyzer</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js" integrity="sha512-4VafBf+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHfoalGoVYLRNvKcJsteVEhDWUpAJZciV06P88GJEpXHIFaY5w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <style>
-body { font-family: Arial, sans-serif; margin: 2em; }
-label { display: block; margin-top: 1em; }
-pre { background: #f4f4f4; padding: 1em; }
+:root {
+  --bg: #fff;
+  --fg: #000;
+  --pre-bg: #f4f4f4;
+  color-scheme: light dark;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121212;
+    --fg: #eee;
+    --pre-bg: #1e1e1e;
+  }
+}
+body {
+  font-family: Arial, sans-serif;
+  margin: 2em;
+  background: var(--bg);
+  color: var(--fg);
+}
+label {
+  display: block;
+  margin-top: 1em;
+}
+pre {
+  background: var(--pre-bg);
+  padding: 1em;
+}
+button {
+  padding: 0.5em 1em;
+  font-size: 1em;
+}
+h1 {
+  font-size: 2em;
+  text-shadow: 0 0 5px #888;
+}
 </style>
 </head>
 <body>

--- a/upload_server.py
+++ b/upload_server.py
@@ -5,13 +5,44 @@ from zombie_transactions import find_recurring_transactions
 
 FORM = """<!doctype html>
 <html>
-<head><title>Zombie Transactions Uploader</title></head>
+<head>
+<title>Zombie Transactions Uploader</title>
+<style>
+:root {
+  --bg: #fff;
+  --fg: #000;
+  --pre-bg: #f4f4f4;
+  color-scheme: light dark;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121212;
+    --fg: #eee;
+    --pre-bg: #1e1e1e;
+  }
+}
+body {
+  font-family: Arial, sans-serif;
+  margin: 2em;
+  background: var(--bg);
+  color: var(--fg);
+}
+pre {
+  background: var(--pre-bg);
+  padding: 1em;
+}
+button {
+  padding: 0.5em 1em;
+  font-size: 1em;
+}
+</style>
+</head>
 <body>
 <h1>Upload CSV</h1>
 <form method="post" enctype="multipart/form-data">
 <input type="file" name="csv_file" accept=".csv"><br>
 Months threshold: <input type="number" name="months" value="2" min="1"><br>
-<input type="submit" value="Analyze">
+<button type="submit">Analyze</button>
 </form>
 <pre>{output}</pre>
 </body>


### PR DESCRIPTION
## Summary
- add CSS variables and prefers-color-scheme support to `docs/index.html`
- update the upload server HTML to use the same dark-mode styling
- mention dark mode capabilities in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4cc0327c832aa38aa837b7d494fb