### PR TITLE
Support PDF uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Prepare a CSV file with at least `Date`, `Description` and `Amount` columns. Run
 python zombie_transactions.py transactions.csv -n 3
 ```
 
+PDF statements can also be analyzed if the optional `PyPDF2` dependency is installed:
+
+```bash
+python zombie_transactions.py statement.pdf -n 3
+```
+
 The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
 
 Rows with missing or malformed data are ignored so you can analyze statements that contain occasional inconsistencies without errors.
@@ -30,4 +36,4 @@ If you prefer a minimal server-based approach, run `upload_server.py`:
 python upload_server.py
 ```
 
-Open [http://localhost:8000](http://localhost:8000) in your browser to upload a CSV file and view recurring transactions.
+Open [http://localhost:8000](http://localhost:8000) in your browser to upload a CSV or PDF file and view recurring transactions. PDF parsing requires the optional `PyPDF2` package.

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,8 +46,8 @@ h1 {
 <body>
 <h1>Zombie Transactions Analyzer</h1>
 <label>
-CSV File:
-<input type="file" id="csvFile" accept=".csv">
+CSV/PDF File:
+<input type="file" id="csvFile" accept=".csv,.pdf">
 </label>
 <label>
 Months threshold:
@@ -92,7 +92,11 @@ function analyze() {
   const months = parseInt(document.getElementById('months').value, 10) || 2;
   const output = document.getElementById('output');
   const file = fileInput.files[0];
-  if (!file) { output.textContent = 'Please select a CSV file.'; return; }
+  if (!file) { output.textContent = 'Please select a CSV or PDF file.'; return; }
+  if (file.name.toLowerCase().endsWith('.pdf')) {
+    output.textContent = 'PDF files are not supported in this demo. Please use the Python script.';
+    return;
+  }
   Papa.parse(file, {
     header: true,
     skipEmptyLines: true,

--- a/zombie_transactions.py
+++ b/zombie_transactions.py
@@ -2,6 +2,7 @@ import csv
 from collections import defaultdict
 from datetime import datetime
 from typing import List, Tuple, Dict
+import io
 
 
 def _get_month(date_str: str) -> str | None:
@@ -17,28 +18,47 @@ def _get_month(date_str: str) -> str | None:
     return None
 
 
+def _load_rows(file_path: str):
+    """Return a list of CSV dict rows from a CSV or PDF file."""
+    if file_path.lower().endswith(".pdf"):
+        try:
+            from PyPDF2 import PdfReader
+        except ImportError as e:
+            raise RuntimeError("PDF support requires PyPDF2 package") from e
+
+        text = ""
+        reader = PdfReader(file_path)
+        for page in reader.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text += page_text + "\n"
+        csv_io = io.StringIO(text)
+        return list(csv.DictReader(csv_io))
+    else:
+        with open(file_path, newline="") as f:
+            return list(csv.DictReader(f))
+
+
 def find_recurring_transactions(
     file_path: str, months_threshold: int = 2
 ) -> List[Tuple[str, float]]:
     """Return a list of (description, amount) that appear in multiple months."""
     seen: Dict[Tuple[str, float], set] = defaultdict(set)
-    with open(file_path, newline="") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            description = (row.get("Description") or row.get("Payee") or "").strip()
-            amount_str = row.get("Amount")
-            date_str = row.get("Date") or row.get("Transaction Date") or ""
+    for row in _load_rows(file_path):
+        description = (row.get("Description") or row.get("Payee") or "").strip()
+        amount_str = row.get("Amount")
+        date_str = row.get("Date") or row.get("Transaction Date") or ""
 
-            try:
-                amount = float(amount_str)
-            except (TypeError, ValueError):
-                continue
+        try:
+            amount = float(amount_str)
+        except (TypeError, ValueError):
+            continue
 
-            month = _get_month(date_str)
-            if not description or month is None:
-                continue
+        month = _get_month(date_str)
+        if not description or month is None:
+            continue
 
-            seen[(description, amount)].add(month)
+        seen[(description, amount)].add(month)
     return [
         (desc, amt) for (desc, amt), months in seen.items() if len(months) >= months_threshold
     ]


### PR DESCRIPTION
## Summary
- add optional PDF parsing using PyPDF2
- allow PDF uploads in the server form
- clarify PDF support in the docs and README
- update JS page to reject PDFs with a hint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4e546cb4832a8251346c209d660f