### PR TITLE
Enable PDF and multi-file uploads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Zombie Transactions Analyzer</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js" integrity="sha512-4VafBf+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHfoalGoVYLRNvKcJsteVEhDWUpAJZciV06P88GJEpXHIFaY5w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.7.107/pdf.min.js" integrity="sha512-k6VKgf/mBlC9ZwTe74MkRUYw35vj0IadB1iKsFcfoTmyaKOA1NVuMcZV8K4D4ew3Efr2E1VlzDq+W8sELpAoKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <style>
 :root {
   --bg: #fff;
@@ -56,8 +57,8 @@ h1 {
 <body>
 <h1>Zombie Transactions Analyzer</h1>
 <label>
-  CSV/PDF File:
-  <input type="file" id="csvFile" accept=".csv,.pdf">
+  CSV/PDF Files:
+  <input type="file" id="csvFile" accept=".csv,.pdf" multiple>
 </label>
 <button id="analyzeBtn">Analyze</button>
 <pre id="output"></pre>
@@ -102,28 +103,61 @@ function guessThreshold(rows) {
   return Math.max(2, Math.ceil(months.size / 2));
 }
 
-function analyze() {
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.7.107/pdf.worker.min.js';
+
+function parsePdf(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = async e => {
+      try {
+        const typed = new Uint8Array(e.target.result);
+        const pdf = await pdfjsLib.getDocument({ data: typed }).promise;
+        let text = '';
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const content = await page.getTextContent();
+          text += content.items.map(it => it.str).join(' ') + '\n';
+        }
+        resolve(text);
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+function parseFile(file) {
+  if (file.name.toLowerCase().endsWith('.pdf')) {
+    return parsePdf(file).then(text => Papa.parse(text, {header: true, skipEmptyLines: true}).data);
+  }
+  return new Promise((resolve, reject) => {
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: results => resolve(results.data),
+      error: reject
+    });
+  });
+}
+
+async function analyze() {
   const fileInput = document.getElementById('csvFile');
   const output = document.getElementById('output');
-  const file = fileInput.files[0];
-  if (!file) { output.textContent = 'Please select a CSV or PDF file.'; return; }
-  if (file.name.toLowerCase().endsWith('.pdf')) {
-    output.textContent = 'PDF files are not supported in this demo. Please use the Python script.';
-    return;
-  }
-  Papa.parse(file, {
-    header: true,
-    skipEmptyLines: true,
-    complete: function(results) {
-      const threshold = guessThreshold(results.data);
-      const recurring = findRecurringTransactions(results.data, threshold);
-      if (recurring.length === 0) {
-        output.textContent = 'No recurring transactions found.';
-      } else {
-        output.textContent = recurring.map(r => `${r.description}: $${r.amount.toFixed(2)}`).join('\n');
-      }
+  const files = Array.from(fileInput.files || []);
+  if (files.length === 0) { output.textContent = 'Please select at least one CSV or PDF file.'; return; }
+  try {
+    const rowsArrays = await Promise.all(files.map(parseFile));
+    const rows = rowsArrays.flat();
+    const threshold = guessThreshold(rows);
+    const recurring = findRecurringTransactions(rows, threshold);
+    if (recurring.length === 0) {
+      output.textContent = 'No recurring transactions found.';
+    } else {
+      output.textContent = recurring.map(r => `${r.description}: $${r.amount.toFixed(2)}`).join('\n');
     }
-  });
+  } catch (err) {
+    output.textContent = 'Error processing files: ' + err.message;
+  }
 }
 
 document.getElementById('analyzeBtn').addEventListener('click', analyze);

--- a/zombie_transactions.py
+++ b/zombie_transactions.py
@@ -1,7 +1,7 @@
 import csv
 from collections import defaultdict
 from datetime import datetime
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Iterable
 import io
 
 
@@ -39,12 +39,12 @@ def _load_rows(file_path: str):
             return list(csv.DictReader(f))
 
 
-def find_recurring_transactions(
-    file_path: str, months_threshold: int = 2
+def find_recurring_transactions_from_rows(
+    rows: Iterable[dict], months_threshold: int = 2
 ) -> List[Tuple[str, float]]:
-    """Return a list of (description, amount) that appear in multiple months."""
+    """Return recurring (description, amount) pairs from an iterable of rows."""
     seen: Dict[Tuple[str, float], set] = defaultdict(set)
-    for row in _load_rows(file_path):
+    for row in rows:
         description = (row.get("Description") or row.get("Payee") or "").strip()
         amount_str = row.get("Amount")
         date_str = row.get("Date") or row.get("Transaction Date") or ""
@@ -62,6 +62,14 @@ def find_recurring_transactions(
     return [
         (desc, amt) for (desc, amt), months in seen.items() if len(months) >= months_threshold
     ]
+
+
+def find_recurring_transactions(
+    file_path: str, months_threshold: int = 2
+) -> List[Tuple[str, float]]:
+    """Return a list of (description, amount) that appear in multiple months."""
+    rows = _load_rows(file_path)
+    return find_recurring_transactions_from_rows(rows, months_threshold)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support multi-file upload and PDF parsing in the web interface
- allow local upload server to accept multiple files
- expose `find_recurring_transactions_from_rows` for convenience

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c52c87ca8832a9ae4f8cc8443fcc9