### PR TITLE
Add fallback CSV parser

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,25 +148,45 @@ function parsePdf(file) {
   });
 }
 
+function parseCsv(text) {
+  if (window.Papa) {
+    return Papa.parse(text, {header: true, skipEmptyLines: true}).data;
+  }
+  log('PapaParse library not loaded, using fallback parser');
+  const lines = text.replace(/\r/g, '').trim().split(/\n+/);
+  if (lines.length === 0) return [];
+  const headers = lines[0].split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(h => h.replace(/^"|"$/g, '').trim());
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const cols = lines[i].split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(c => c.replace(/^"|"$/g, '').trim());
+    const row = {};
+    headers.forEach((h, j) => { row[h] = cols[j] || ''; });
+    rows.push(row);
+  }
+  return rows;
+}
+
 function parseFile(file) {
   log('Reading ' + file.name);
-  if (!window.Papa) {
-    return Promise.reject(new Error('PapaParse library not loaded'));
-  }
   if (file.name.toLowerCase().endsWith('.pdf')) {
     return parsePdf(file).then(text => {
-      const rows = Papa.parse(text, {header: true, skipEmptyLines: true}).data;
+      const rows = parseCsv(text);
       log('Parsed ' + rows.length + ' rows from ' + file.name);
       return rows;
     });
   }
   return new Promise((resolve, reject) => {
-    Papa.parse(file, {
-      header: true,
-      skipEmptyLines: true,
-      complete: results => { log('Parsed ' + results.data.length + ' rows from ' + file.name); resolve(results.data); },
-      error: reject
-    });
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const rows = parseCsv(e.target.result);
+        log('Parsed ' + rows.length + ' rows from ' + file.name);
+        resolve(rows);
+      } catch (err) { reject(err); }
+    };
+    reader.onerror = reject;
+    reader.readAsText(file);
   });
 }
 


### PR DESCRIPTION
## Summary
- add a small CSV parser in the web interface
- use the fallback parser if PapaParse isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5bc77b48832a945df5e556c0a993