### PR TITLE
Add offline result caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ may fail on heavily compressed documents.
 
 The page now supports dark mode automatically and features an improved layout for an epic experience.
 
+Your last analysis results are stored in your browser so you can reopen
+`docs/index.html` later and review them even without an internet
+connection.
+
 
 ## Local upload server
 If you prefer a minimal server-based approach, run `upload_server.py`:

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,6 +73,13 @@ function log(msg) {
   el.textContent += msg + '\n';
   el.scrollTop = el.scrollHeight;
 }
+window.addEventListener('load', () => {
+  const saved = localStorage.getItem('zombieOutput');
+  if (saved) {
+    document.getElementById('output').textContent = saved;
+    log('Loaded results from offline storage');
+  }
+});
 function getMonth(dateStr) {
   const d = new Date(dateStr);
   if (isNaN(d)) throw new Error('Unrecognized date format: ' + dateStr);
@@ -205,6 +212,7 @@ async function analyze() {
     } else {
       output.textContent = recurring.map(r => `${r.description}: $${r.amount.toFixed(2)}`).join('\n');
     }
+    localStorage.setItem('zombieOutput', output.textContent);
   } catch (err) {
     output.textContent = 'Error processing files: ' + err.message;
     log('Error: ' + err.message);


### PR DESCRIPTION
## Summary
- store analysis results in browser localStorage and load them on page load
- document the offline caching feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6443c328832a8be55d96b8d1583e