### PR TITLE
Remove ratio input

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ python zombie_transactions.py statement.png -n 3
 The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
 
 Pass `--fuzzy` to enable AI-powered fuzzy matching of description strings so that
-minor variations like different casing or punctuation are grouped together. The
-`--ratio-threshold` option controls the required similarity (default 0.8).
+minor variations like different casing or punctuation are grouped together.
 
 Rows with missing or malformed data are ignored so you can analyze statements that contain occasional inconsistencies without errors.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,7 +64,6 @@ h1 {
   Files:
   <input type="file" id="csvFile" accept=".csv,.txt,.pdf,.png,.jpg,.jpeg" multiple>
 </label>
-<label>Ratio: <input type="number" id="ratio" min="0" max="1" step="0.05" value="0.8"></label>
 <button id="analyzeBtn">Analyze</button>
 <pre id="output"></pre>
 <pre id="log"></pre>
@@ -277,7 +276,7 @@ async function analyze() {
     const rows = rowsArrays.flat();
     const threshold = guessThreshold(rows);
     log('Using threshold of ' + threshold + ' month(s)');
-    const ratio = parseFloat(document.getElementById('ratio').value) || 0.8;
+    const ratio = 0.8;
     const recurring = findRecurringTransactions(rows, threshold, ratio);
     log('Found ' + recurring.length + ' recurring transaction(s)');
     if (recurring.length === 0) {


### PR DESCRIPTION
## Summary
- hide ratio threshold input from web UI
- use a fixed default ratio in the browser script
- stop mentioning ratio threshold in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb398f10c832a805899182eacb145