### PR TITLE
Improve PDF extraction handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Prepare a CSV file with at least `Date`, `Description` and `Amount` columns. Run
 python zombie_transactions.py transactions.csv -n 3
 ```
 
-PDF statements can also be analyzed if the optional `PyPDF2` dependency is installed.  
+PDF statements can also be analyzed when `PyPDF2` or `pdfminer.six` are available.
+If these libraries cannot extract text, the tool will attempt OCR when `pdf2image`,
+`pytesseract` and `Pillow` are installed.
 Text files (`.txt`) and image files containing statement screenshots (`.png`, `.jpg`) are supported when `pytesseract` and `Pillow` are available:
 
 ```bash
@@ -36,8 +38,8 @@ The web interface is now completely self contained. You can open
 analyze CSV files or simple PDF statements. Parsing and grouping of
 descriptions now relies on a lightweight AI model that runs entirely in your
 browser so recurring transactions are found even when descriptions vary
-slightly. PDF parsing is best effort and may fail on heavily compressed
-documents.
+slightly. PDF parsing now falls back to client-side OCR when direct extraction
+fails so even scanned statements can be analyzed.
 
 The page now supports dark mode automatically and features an improved layout for an epic experience.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,7 +166,18 @@ function guessThreshold(rows) {
   return Math.max(2, Math.ceil(months.size / 2));
 }
 
-function parsePdf(file) {
+function loadPdfJs() {
+  if (window.pdfjsLib) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.1.392/pdf.min.js';
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('Failed to load pdf.js'));
+    document.head.appendChild(s);
+  });
+}
+
+function simpleParsePdf(file) {
   log('Parsing PDF (simple parser): ' + file.name);
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -186,7 +197,7 @@ function parsePdf(file) {
           parts.push(joined);
         }
         if (parts.length === 0) {
-          reject(new Error('Unable to extract text from PDF'));
+          reject(new Error('No text'));
           return;
         }
         resolve(parts.join('\n'));
@@ -195,6 +206,60 @@ function parsePdf(file) {
     reader.onerror = reject;
     reader.readAsArrayBuffer(file);
   });
+}
+
+function pdfjsExtract(file) {
+  log('Parsing PDF with pdf.js: ' + file.name);
+  return loadPdfJs().then(() => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const data = new Uint8Array(e.target.result);
+      pdfjsLib.getDocument({data}).promise.then(async doc => {
+        let text = '';
+        for (let i = 1; i <= doc.numPages; i++) {
+          const page = await doc.getPage(i);
+          const content = await page.getTextContent();
+          const strings = content.items.map(it => it.str).join(' ');
+          if (strings) text += strings + '\n';
+        }
+        if (text.trim()) resolve(text); else reject(new Error('No text'));
+      }).catch(reject);
+    };
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(file);
+  }));
+}
+
+function pdfjsOcr(file) {
+  log('Running OCR on PDF: ' + file.name);
+  return Promise.all([loadPdfJs(), loadTesseract()]).then(() => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const data = new Uint8Array(e.target.result);
+      pdfjsLib.getDocument({data}).promise.then(async doc => {
+        let text = '';
+        for (let i = 1; i <= doc.numPages; i++) {
+          const page = await doc.getPage(i);
+          const viewport = page.getViewport({scale: 2});
+          const canvas = document.createElement('canvas');
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          await page.render({canvasContext: canvas.getContext('2d'), viewport}).promise;
+          const result = await window.Tesseract.recognize(canvas, 'eng');
+          text += result.data.text + '\n';
+        }
+        if (text.trim()) resolve(text); else reject(new Error('No text'));
+      }).catch(reject);
+    };
+    reader.onerror = reject;
+    reader.readAsArrayBuffer(file);
+  }));
+}
+
+function parsePdf(file) {
+  return simpleParsePdf(file)
+    .catch(() => pdfjsExtract(file))
+    .catch(() => pdfjsOcr(file));
 }
 
 function loadTesseract() {


### PR DESCRIPTION
## Summary
- add OCR and pdfminer fallbacks to `_load_rows`
- enhance web parser with pdf.js-based extraction and OCR fallback
- update README for new PDF handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb601b7a0832a8224ecbbe385f7bc