### PR TITLE
Use AI OCR for PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ A basic web interface is available under `docs/`. GitHub Pages can serve this di
 The web interface is now completely self contained. You can open
 `docs/index.html` directly in your browser without an internet connection and
 analyze CSV files or simple PDF statements. Parsing and grouping of
-descriptions now relies on a lightweight AI model that runs entirely in your
+descriptions relies on a lightweight AI model that runs entirely in your
 browser so recurring transactions are found even when descriptions vary
-slightly. PDF parsing now falls back to client-side OCR when direct extraction
-fails so even scanned statements can be analyzed.
+slightly. PDF parsing uses a simple extractor and falls back to AI-powered OCR
+when needed so even scanned statements can be analyzed without relying on
+`pdf.js`.
 
 The page now supports dark mode automatically and features an improved layout for an epic experience.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,16 +166,6 @@ function guessThreshold(rows) {
   return Math.max(2, Math.ceil(months.size / 2));
 }
 
-function loadPdfJs() {
-  if (window.pdfjsLib) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const s = document.createElement('script');
-    s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.1.392/pdf.min.js';
-    s.onload = () => resolve();
-    s.onerror = () => reject(new Error('Failed to load pdf.js'));
-    document.head.appendChild(s);
-  });
-}
 
 function simpleParsePdf(file) {
   log('Parsing PDF (simple parser): ' + file.name);
@@ -208,58 +198,17 @@ function simpleParsePdf(file) {
   });
 }
 
-function pdfjsExtract(file) {
-  log('Parsing PDF with pdf.js: ' + file.name);
-  return loadPdfJs().then(() => new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      const data = new Uint8Array(e.target.result);
-      pdfjsLib.getDocument({data}).promise.then(async doc => {
-        let text = '';
-        for (let i = 1; i <= doc.numPages; i++) {
-          const page = await doc.getPage(i);
-          const content = await page.getTextContent();
-          const strings = content.items.map(it => it.str).join(' ');
-          if (strings) text += strings + '\n';
-        }
-        if (text.trim()) resolve(text); else reject(new Error('No text'));
-      }).catch(reject);
-    };
-    reader.onerror = reject;
-    reader.readAsArrayBuffer(file);
-  }));
-}
 
-function pdfjsOcr(file) {
+function ocrPdf(file) {
   log('Running OCR on PDF: ' + file.name);
-  return Promise.all([loadPdfJs(), loadTesseract()]).then(() => new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      const data = new Uint8Array(e.target.result);
-      pdfjsLib.getDocument({data}).promise.then(async doc => {
-        let text = '';
-        for (let i = 1; i <= doc.numPages; i++) {
-          const page = await doc.getPage(i);
-          const viewport = page.getViewport({scale: 2});
-          const canvas = document.createElement('canvas');
-          canvas.width = viewport.width;
-          canvas.height = viewport.height;
-          await page.render({canvasContext: canvas.getContext('2d'), viewport}).promise;
-          const result = await window.Tesseract.recognize(canvas, 'eng');
-          text += result.data.text + '\n';
-        }
-        if (text.trim()) resolve(text); else reject(new Error('No text'));
-      }).catch(reject);
-    };
-    reader.onerror = reject;
-    reader.readAsArrayBuffer(file);
-  }));
+  return loadTesseract().then(() => {
+    return window.Tesseract.recognize(file, 'eng');
+  }).then(result => result.data.text);
 }
 
 function parsePdf(file) {
   return simpleParsePdf(file)
-    .catch(() => pdfjsExtract(file))
-    .catch(() => pdfjsOcr(file));
+    .catch(() => ocrPdf(file));
 }
 
 function loadTesseract() {


### PR DESCRIPTION
## Summary
- remove pdf.js extraction logic
- rely on a simple parser then Tesseract OCR for PDF text
- update README to mention OCR-based approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4e646ba8832a9998586b52315736