### PR TITLE
Add automatic threshold feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ python zombie_transactions.py statement.png -n 3
 ```
 
 The `-n`/`--months` option controls how many distinct months a charge must appear in to be reported.
+Use `-a`/`--auto-threshold` to let the tool pick an appropriate threshold based on
+the range of months present in your statements.
 
 Pass `--fuzzy` to enable AI-powered fuzzy matching of description strings. When
 the optional [spaCy](https://spacy.io/) library and an English model are

--- a/tests/test_zombie_transactions.py
+++ b/tests/test_zombie_transactions.py
@@ -79,6 +79,31 @@ bad-date,ServiceX,9.99
             desc, amt = results[0]
             self.assertAlmostEqual(amt, 10.0)
 
+    def test_auto_threshold(self):
+        auto_csv = """Date,Description,Amount
+2024-01-01,ServiceA,10
+2024-02-01,ServiceA,10
+2024-03-01,ServiceA,10
+2024-04-01,ServiceA,10
+2024-05-01,ServiceA,10
+2024-01-05,ServiceB,5
+2024-02-05,ServiceB,5
+2024-03-05,ServiceB,5
+2024-01-10,ServiceC,2
+2024-02-10,ServiceC,2
+"""
+        with io.StringIO(auto_csv) as f:
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tf:
+                tf.write(f.getvalue())
+                path = tf.name
+
+            results = find_recurring_transactions(path, months_threshold=None)
+            self.assertIn(("ServiceA", 10.0), results)
+            self.assertIn(("ServiceB", 5.0), results)
+            self.assertNotIn(("ServiceC", 2.0), results)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/upload_server.py
+++ b/upload_server.py
@@ -5,7 +5,7 @@ import os
 from zombie_transactions import (
     find_recurring_transactions_from_rows,
     _load_rows,
-    _get_month,
+    guess_threshold,
 )
 
 FORM = """<!doctype html>
@@ -98,7 +98,7 @@ class UploadHandler(http.server.BaseHTTPRequestHandler):
                 path = tf.name
             rows.extend(_load_rows(path))
         if rows:
-            threshold = self._guess_threshold_rows(rows)
+            threshold = guess_threshold(rows)
             results = find_recurring_transactions_from_rows(
                 rows, months_threshold=threshold, fuzzy=True
             )
@@ -111,13 +111,6 @@ class UploadHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(FORM.format(output=output).encode())
 
-    def _guess_threshold_rows(self, rows) -> int:
-        months = set()
-        for row in rows:
-            month = _get_month(row.get("Date") or row.get("Transaction Date") or "")
-            if month:
-                months.add(month)
-        return max(2, (len(months) + 1) // 2)
 
 def run(server_class=http.server.HTTPServer, handler_class=UploadHandler, port=8000):
     server_address = ("", port)


### PR DESCRIPTION
## Summary
- allow automatic months threshold for recurring transaction detection
- expose new `-a/--auto-threshold` CLI flag
- update upload server to use the shared threshold logic
- document new option in README
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6e1be5d8832a8221c6d2d7df4ae0