### PR TITLE
Add Plaid integration scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,27 @@ python upload_server.py
 ```
 
 Open [http://localhost:8000](http://localhost:8000) in your browser to upload a CSV, text, PDF or image file and view recurring transactions. PDF and image parsing require the optional `PyPDF2`, `pytesseract` and `Pillow` packages.
+
+## Plaid bank integration
+To fetch transactions directly from your bank, first install the optional
+`plaid-python` and `flask` packages and set the following environment variables:
+
+```
+PLAID_CLIENT_ID=<your client id>
+PLAID_SECRET=<your secret>
+PLAID_ENV=sandbox  # or 'development' / 'production'
+```
+
+Run `plaid_link_server.py` and open [http://localhost:5000](http://localhost:5000)
+ in your browser. Use the Plaid Link flow to connect your account. The resulting
+access token will be saved to `plaid_access_token.txt`.
+
+Transactions can then be downloaded and analyzed:
+
+```bash
+python plaid_fetch.py plaid_access_token.txt --analyze
+```
+
+The script will fetch recent transactions, save them to CSV when requested and
+report any recurring charges using the same logic as the CLI and web interface.
+

--- a/plaid_fetch.py
+++ b/plaid_fetch.py
@@ -1,0 +1,86 @@
+import os
+import csv
+from datetime import date, timedelta
+from typing import Iterable, List, Dict, Optional
+try:
+    from plaid import Client
+except Exception:  # pragma: no cover - optional dependency
+    Client = None  # type: ignore
+
+
+def create_client() -> Client:
+    if Client is None:
+        raise ImportError("plaid package is required for Plaid integration")
+    return Client(
+        client_id=os.environ["PLAID_CLIENT_ID"],
+        secret=os.environ["PLAID_SECRET"],
+        environment=os.getenv("PLAID_ENV", "sandbox"),
+    )
+
+
+def fetch_transactions(
+    access_token: str,
+    start_date: str,
+    end_date: str,
+    client: Optional[Client] = None,
+) -> List[Dict]:
+    client = client or create_client()
+    if client is None:
+        raise ImportError("plaid package is required for Plaid integration")
+    resp = client.Transactions.get(access_token, start_date=start_date, end_date=end_date)
+    return resp.get("transactions", [])
+
+
+def save_csv(transactions: Iterable[Dict], path: str) -> None:
+    rows = [
+        [t["date"], t["name"], t["amount"]]
+        for t in transactions
+    ]
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Date", "Description", "Amount"])
+        writer.writerows(rows)
+
+
+def main() -> None:
+    import argparse
+
+    default_start = (date.today() - timedelta(days=90)).isoformat()
+    parser = argparse.ArgumentParser(
+        description="Fetch transactions from Plaid and analyze recurring charges"
+    )
+    parser.add_argument("access_token", help="Plaid access token or path to token file")
+    parser.add_argument("--start", default=default_start, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", default=date.today().isoformat(), help="End date YYYY-MM-DD")
+    parser.add_argument("--csv", help="Optional CSV output file")
+    parser.add_argument("--analyze", action="store_true", help="Analyze recurring transactions")
+    args = parser.parse_args()
+
+    token = args.access_token
+    if os.path.isfile(token):
+        with open(token) as f:
+            token = f.read().strip()
+
+    transactions = fetch_transactions(token, args.start, args.end)
+    if args.csv:
+        save_csv(transactions, args.csv)
+    if args.analyze:
+        rows = [
+            {"Date": t["date"], "Description": t["name"], "Amount": t["amount"]}
+            for t in transactions
+        ]
+        from zombie_transactions import find_recurring_transactions_from_rows, guess_threshold
+
+        threshold = guess_threshold(rows)
+        results = find_recurring_transactions_from_rows(rows, months_threshold=threshold, fuzzy=True)
+        if results:
+            for desc, amt in results:
+                print(f"{desc}: ${amt:.2f}")
+        else:
+            print("No recurring transactions found.")
+    else:
+        print(f"Fetched {len(transactions)} transactions")
+
+
+if __name__ == "__main__":
+    main()

--- a/plaid_link_server.py
+++ b/plaid_link_server.py
@@ -1,0 +1,73 @@
+import os
+from flask import Flask, request, jsonify, render_template_string
+from plaid import Client
+
+
+app = Flask(__name__)
+
+
+def _create_client() -> Client:
+    return Client(
+        client_id=os.environ["PLAID_CLIENT_ID"],
+        secret=os.environ["PLAID_SECRET"],
+        environment=os.getenv("PLAID_ENV", "sandbox"),
+    )
+
+
+HTML_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <title>Connect Bank Account</title>
+  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+</head>
+<body>
+<button id="link-button">Connect Bank</button>
+<script>
+fetch('/create-link-token').then(r => r.json()).then(data => {
+  var handler = Plaid.create({
+    token: data.link_token,
+    onSuccess: function(public_token) {
+      fetch('/exchange', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({public_token: public_token})})
+        .then(() => alert('Access token saved to plaid_access_token.txt')); 
+    }
+  });
+  document.getElementById('link-button').onclick = function() { handler.open(); };
+});
+</script>
+</body>
+</html>"""
+
+
+@app.route("/")
+def index():
+    return render_template_string(HTML_TEMPLATE)
+
+
+@app.route("/create-link-token")
+def create_link_token():
+    client = _create_client()
+    response = client.LinkToken.create(
+        {
+            "user": {"client_user_id": "user"},
+            "client_name": "Zombie Transactions",
+            "products": ["transactions"],
+            "country_codes": ["US"],
+            "language": "en",
+        }
+    )
+    return jsonify({"link_token": response["link_token"]})
+
+
+@app.route("/exchange", methods=["POST"])
+def exchange():
+    public_token = request.json.get("public_token")
+    client = _create_client()
+    exchange = client.Item.public_token.exchange(public_token)
+    access_token = exchange["access_token"]
+    with open("plaid_access_token.txt", "w") as f:
+        f.write(access_token)
+    return jsonify({"status": "ok"})
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/tests/test_plaid_fetch.py
+++ b/tests/test_plaid_fetch.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from plaid_fetch import fetch_transactions
+
+
+class StubTransactions:
+    def get(self, token, start_date=None, end_date=None):
+        return {
+            "transactions": [
+                {"date": "2024-01-01", "name": "Test", "amount": 1.23},
+            ]
+        }
+
+
+class StubClient:
+    Transactions = StubTransactions()
+
+
+class PlaidFetchTest(unittest.TestCase):
+    def test_fetch_transactions(self):
+        txns = fetch_transactions("token", "2024-01-01", "2024-01-31", client=StubClient())
+        self.assertEqual(len(txns), 1)
+        self.assertEqual(txns[0]["name"], "Test")
+        self.assertEqual(txns[0]["amount"], 1.23)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `plaid_link_server.py` to allow connecting to a bank via Plaid Link
- add `plaid_fetch.py` script to fetch transactions and optionally analyze them
- document Plaid integration in README
- test Plaid transaction fetching with stub client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d83925a48832a9df79f79f6dd084c